### PR TITLE
perf(NEGGIA-001): worker pool replacing GLOBAL_HANDLE singleton

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,10 @@ on: [push, pull_request]
 # gtest-death-test.cc:1224 trips a stricter modern warning that gtest's
 # own -Werror config treats as a build break. Lessons inherited from
 # dectris-cloud/xds XDS-039 work.
+#
+# Plugin .so is uploaded per lane as a GitHub Actions artifact so
+# downstream consumers (XDS-fork CI; scientists-in-cloud validation
+# nodes) can download a built plugin without rebuilding.
 
 jobs:
   posix-cc:
@@ -49,6 +53,14 @@ jobs:
       - name: Test
         run: ctest --output-on-failure
         working-directory: ${{github.workspace}}.build
+      - name: Upload dectris-neggia.so + sha256
+        uses: actions/upload-artifact@v4
+        with:
+          name: dectris-neggia-${{ matrix.os }}-${{ matrix.build-type }}-cc
+          path: |
+            ${{github.workspace}}.build/src/dectris/neggia/plugin/dectris-neggia.so
+          if-no-files-found: error
+          retention-days: 90
 
   posix-gcc:
     strategy:
@@ -91,3 +103,11 @@ jobs:
       - name: Test
         run: ctest --output-on-failure
         working-directory: ${{github.workspace}}.build
+      - name: Upload dectris-neggia.so + sha256
+        uses: actions/upload-artifact@v4
+        with:
+          name: dectris-neggia-${{ matrix.os }}-${{ matrix.build-type }}-gcc${{ matrix.gcc-version }}
+          path: |
+            ${{github.workspace}}.build/src/dectris/neggia/plugin/dectris-neggia.so
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,10 @@ on: [push, pull_request]
 # NEGGIA-001: modernised runner labels (replaced retired
 # ubuntu-18.04/20.04 + macos-10.15 + ubuntu-16.04) and added the
 # cmake 4.x policy workaround for googletest's
-# cmake_minimum_required(VERSION <3.5). Lesson inherited from
+# cmake_minimum_required(VERSION <3.5). Linux gcc-11+ also needed
+# -Wno-error=maybe-uninitialized because vendored googletest's
+# gtest-death-test.cc:1224 trips a stricter modern warning that gtest's
+# own -Werror config treats as a build break. Lessons inherited from
 # dectris-cloud/xds XDS-039 work.
 
 jobs:
@@ -21,6 +24,11 @@ jobs:
           - build-type: Release
             debug-parsing: OFF
     runs-on: ${{ matrix.os }}
+    env:
+      # Vendored googletest trips -Werror=maybe-uninitialized on modern
+      # gcc-11+ (Linux). macOS Apple clang doesn't enable this by default.
+      # Override here rather than mutate the vendored submodule.
+      CXXFLAGS: -Wno-error=maybe-uninitialized
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,6 +68,8 @@ jobs:
             gcc-version: 13
             os: ubuntu-24.04
     runs-on: ${{ matrix.os }}
+    env:
+      CXXFLAGS: -Wno-error=maybe-uninitialized
     steps:
       - name: Install Packages
         run: sudo apt-get update && sudo apt-get install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,19 @@ name: Build and Test
 
 on: [push, pull_request]
 
+# NEGGIA-001: modernised runner labels (replaced retired
+# ubuntu-18.04/20.04 + macos-10.15 + ubuntu-16.04) and added the
+# cmake 4.x policy workaround for googletest's
+# cmake_minimum_required(VERSION <3.5). Lesson inherited from
+# dectris-cloud/xds XDS-039 work.
+
 jobs:
   posix-cc:
     strategy:
+      fail-fast: false
       matrix:
         build-type: [Debug, Release]
-        os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-14, macos-15-intel, ubuntu-22.04, ubuntu-24.04]
         include:
           - build-type: Debug
             debug-parsing: ON
@@ -16,13 +23,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}.build
       - name: Configure CMake
-        run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DDEBUG_PARSING=${{matrix.debug-parsing}}
+        # -DCMAKE_POLICY_VERSION_MINIMUM=3.5: cmake 4.x dropped support for
+        # the cmake_minimum_required(VERSION 2.6.4) declaration in the
+        # vendored googletest submodule; the flag relaxes policy enforcement.
+        # Safe no-op on cmake 3.x (Ubuntu apt).
+        run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DDEBUG_PARSING=${{matrix.debug-parsing}} -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         working-directory: ${{github.workspace}}.build
       - name: Build
         run: cmake --build .
@@ -33,32 +44,33 @@ jobs:
 
   posix-gcc:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - build-type: Debug
-            gcc-version: 4.8
-            os: ubuntu-16.04
+            gcc-version: 11
+            os: ubuntu-22.04
           - build-type: Debug
-            gcc-version: 10
-            os: ubuntu-20.04
+            gcc-version: 13
+            os: ubuntu-24.04
           - build-type: Release
-            gcc-version: 4.8
-            os: ubuntu-16.04
+            gcc-version: 11
+            os: ubuntu-22.04
           - build-type: Release
-            gcc-version: 10
-            os: ubuntu-20.04
+            gcc-version: 13
+            os: ubuntu-24.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Packages
-        run: sudo apt-get install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }}
+        run: sudo apt-get update && sudo apt-get install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}.build
       - name: Configure CMake
-        run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DDEBUG_PARSING=ON
+        run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DDEBUG_PARSING=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         env:
           CC: gcc-${{ matrix.gcc-version }}
           CXX: g++-${{ matrix.gcc-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,6 @@ on: [push, pull_request]
 # gtest-death-test.cc:1224 trips a stricter modern warning that gtest's
 # own -Werror config treats as a build break. Lessons inherited from
 # dectris-cloud/xds XDS-039 work.
-#
-# Plugin .so is uploaded per lane as a GitHub Actions artifact so
-# downstream consumers (XDS-fork CI; scientists-in-cloud validation
-# nodes) can download a built plugin without rebuilding.
 
 jobs:
   posix-cc:
@@ -53,14 +49,6 @@ jobs:
       - name: Test
         run: ctest --output-on-failure
         working-directory: ${{github.workspace}}.build
-      - name: Upload dectris-neggia.so + sha256
-        uses: actions/upload-artifact@v4
-        with:
-          name: dectris-neggia-${{ matrix.os }}-${{ matrix.build-type }}-cc
-          path: |
-            ${{github.workspace}}.build/src/dectris/neggia/plugin/dectris-neggia.so
-          if-no-files-found: error
-          retention-days: 90
 
   posix-gcc:
     strategy:
@@ -103,11 +91,3 @@ jobs:
       - name: Test
         run: ctest --output-on-failure
         working-directory: ${{github.workspace}}.build
-      - name: Upload dectris-neggia.so + sha256
-        uses: actions/upload-artifact@v4
-        with:
-          name: dectris-neggia-${{ matrix.os }}-${{ matrix.build-type }}-gcc${{ matrix.gcc-version }}
-          path: |
-            ${{github.workspace}}.build/src/dectris/neggia/plugin/dectris-neggia.so
-          if-no-files-found: error
-          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,30 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-(no changes yet — framework bootstrapped 2026-05-29, work on NEGGIA-001
-worker-pool replacing GLOBAL_HANDLE pending)
+### Changed
+- **Worker pool replaces `GLOBAL_HANDLE` singleton** (NEGGIA-001 —
+  Stage 1 of Tier-1 perf overhaul per XDS-037 RFC). The plugin layer
+  now holds `NUM_WORKERS=16` `H5DataCache` instances, each with its
+  own `H5File` (own mmap = own kernel readahead state — load-bearing
+  for the GeeseFS-S3 concurrency win). `plugin_get_data` dispatches by
+  `frame_number % NUM_WORKERS` for a lock-free hot path; per-worker
+  state is thread-confined (per audit Inv-A: H5DataCache is
+  write-once-then-immutable after `plugin_get_header`). External
+  single-open contract preserved (stderr message verbatim on second
+  open while pool active). The 4 sacred C ABI symbols (`plugin_open`,
+  `plugin_close`, `plugin_get_header`, `plugin_get_data`) retain
+  byte-identical signatures — XDS-fork's `tools/neggia-version.txt`
+  bump path stays clean. New `Test_XdsPluginConcurrent` (16 threads ×
+  100 calls, bit-equality vs single-threaded reference) verifies the
+  concurrency surface; passes ctest + TSan clean (Helgrind verification
+  deferred to Linux CI — unavailable on macOS arm64). Bit-exact
+  regression against pre-patch `.so` verified on 9 fixtures across
+  `datasets_eiger1` + `datasets_eiger2` (uint16/uint32/uint8;
+  BSLZ4/LZ4/uncompressed; 0/2 data-file variants). Scientists-in-cloud
+  GeeseFS-S3 benchmark target (≥1.3× wall-clock speedup) deferred to
+  NEGGIA-005 release-time validation. Reporter-authorized cap exemption
+  recorded (67/50 cap units ≈ 1.3× cap; precedent XDS-036; cap reaffirmed
+  for subsequent tickets). — closes NEGGIA-001
 
 ## [1.2.0] — 2021-03-26
 

--- a/docs/audits/NEGGIA-001.md
+++ b/docs/audits/NEGGIA-001.md
@@ -1,0 +1,618 @@
+# Audit: NEGGIA-001 — Worker pool replacing GLOBAL_HANDLE singleton
+
+## Spec Reference
+`docs/specs/NEGGIA-001.md`
+
+## Note on audit dispatch
+This audit was dispatched via `general-purpose` (not `neggia-archaeologist`)
+because the agent type was added mid-session and isn't loaded into the
+dispatcher until next session. Next NEGGIA-NNN ticket can dispatch
+`neggia-archaeologist` directly. Findings are equivalent — same tools,
+same prompt brief, just a different dispatcher route this once.
+
+---
+
+## 1. Symbol / File Inventory
+
+- **`GLOBAL_HANDLE`** — `src/dectris/neggia/plugin/H5ToXds.cpp:31` —
+  file-scope `std::unique_ptr<H5DataCache>` in anonymous namespace;
+  the singleton holding the one open dataset's parsed-cache state.
+- **`H5DataCache` (struct)** — `src/dectris/neggia/plugin/H5ToXds.cpp:18-29` —
+  **defined inline as a POD-like struct inside the anonymous namespace
+  of `H5ToXds.cpp`**. **There is NO separate `H5DataCache.{h,cpp}`**.
+  Members: `filename`, `H5File h5File`, `dimx`, `dimy`, `datasize`,
+  `nframesPerDataset`, `mask`, `xpixelSize`, `ypixelSize`,
+  `masterFileOnly`. Role: holds parsed header metadata + pixel mask +
+  mmap handle for one open dataset.
+- **`plugin_open`** — `H5ToXds.cpp:418-439` — C ABI. Constructs a new
+  `H5DataCache`, opens master file via `H5File` ctor (line 425), then
+  checks `if (GLOBAL_HANDLE)` at **line 431** (spec/ticket cite "line
+  423" — actual is 431). Refusal at 432: `"CAN ONLY OPEN ONE FILE AT
+  A TIME"`. On success: `std::move` into `GLOBAL_HANDLE` (line 437).
+- **`plugin_get_header`** — `H5ToXds.cpp:441-473` — C ABI. Calls
+  `getPreopenedDataCache()` (line 451), then mutates `dataCache->*`
+  via `setXPixelSize`/`setYPixelSize`/`setPixelMask`/
+  `setNFramesPerDataset` (lines 452-457). **All H5DataCache mutation
+  happens here in this single one-shot during the open/header phase.**
+- **`plugin_get_data`** — `H5ToXds.cpp:475-491` — C ABI. Calls
+  `getPreopenedDataCache()` (line 483), then `readDataset(frame_number,
+  data_array, dataCache)` (line 484). `readDataset` (lines 381-402)
+  reads `dataCache` fields only and writes only to caller-supplied
+  `data_array`. **No mutation in this call chain.**
+- **`plugin_close`** — `H5ToXds.cpp:493-495` — C ABI. `GLOBAL_HANDLE.reset()`.
+  **Audit-surfaced bug (out-of-scope):** `error_flag` is never assigned.
+- **`H5File`** — `src/dectris/neggia/user/H5File.{h,cpp}`. RAII mmap
+  wrapper. Holds `std::shared_ptr<char> _fileAddress` with custom
+  `UnMap` deleter capturing `fsize`. **fd is `close(fd)`'d at
+  `H5File.cpp:37` immediately after `mmap` — H5File does NOT retain
+  the fd**.
+- **`Dataset`** — `src/dectris/neggia/user/Dataset.{h,cpp}`. `Dataset::read`
+  is `const`; instances are constructed per-call inside `readDataset`
+  (`H5ToXds.cpp:387`).
+- **`getPreopenedDataCache()`** — `H5ToXds.cpp:142-148` — file-scope
+  helper that reads `GLOBAL_HANDLE.get()` and throws if null. **The
+  single read site of `GLOBAL_HANDLE` outside open/close.**
+
+---
+
+## 2. Threading Model
+
+### GLOBAL_HANDLE
+- **Current**: main-only; **post-NEGGIA-001**: removed entirely.
+- Synchronization: NONE. Raw `std::unique_ptr` at file scope. No mutex,
+  no atomic, no thread_local.
+- Invariant: exactly one live `H5DataCache` between matched
+  `plugin_open`/`plugin_close`; refusal at `H5ToXds.cpp:431-435`
+  enforces single-open externally.
+
+### H5DataCache
+- **Current**: main-only. **Post-NEGGIA-001 (candidate a, recommended)**:
+  per-worker ownership → each instance is thread-confined; NO cross-thread
+  mutation.
+- Synchronization: NONE needed under per-worker ownership.
+- **Inv-A — load-bearing**: All mutating writes to `dataCache->*` happen
+  inside `plugin_open` (lines 424-425) and `plugin_get_header` callees
+  (lines 182, 184, 191, 193, 232-235, 240-282, 331-334, 349, 352).
+  After header phase: **field-immutable**. `plugin_get_data` reads only.
+- Source: `src/dectris/neggia/plugin/H5ToXds.cpp:18-29` (struct);
+  comprehensive grep confirms 100% of `dataCache->` writes inside
+  open/header phase.
+
+### H5File
+- **Current**: main-only. **Post-NEGGIA-001**: shareable across worker
+  threads as a read-only handle.
+- Synchronization: relies on `std::shared_ptr<char>` standard-guaranteed
+  thread-safe refcounting + PROT_READ kernel enforcement.
+- **Inv-B**: H5File is safely copyable across threads. mmap region is
+  `PROT_READ | MAP_SHARED`; fd is `close()`'d at construction (line 37);
+  sharing across N workers does NOT multiply fds OR mmaps (shared_ptr
+  refcount keeps one underlying mmap).
+- Source: `user/H5File.cpp:30` (PROT_READ mmap), `:37` (fd close),
+  `user/H5File.h:17` (`std::shared_ptr<char> _fileAddress`).
+
+### Dataset
+- **Inv-C**: per-call stack-local; `Dataset::read()` is `const`. No
+  mutable cross-call state at Dataset layer. Source: `user/Dataset.cpp:111`.
+
+### plugin_* (the 4 C ABI symbols)
+- **Current**: main-only. **Post-NEGGIA-001 target**: `plugin_get_data`
+  data-race-free under N-thread concurrent calls; `plugin_open`/
+  `plugin_close` remain single-threaded (called once at session
+  start/end by XDS-fork via dlsym).
+- Synchronization: pool initialization happens-before any get_data call
+  (sequenced by Fortran caller: open → header → loop(get_data) → close).
+  Per-worker dispatch by `frame_number % K` — no synchronization on
+  the hot path.
+- **Invariant**: the four C symbol signatures MUST NOT CHANGE
+  (Hard Rule 4 of agent framework; baselined in `docs/abi-baseline.txt`).
+- Source: `H5ToXds.cpp:418, 441, 475, 493`; `H5ToXds.h:17-35`.
+
+---
+
+## 3. Call Graph
+
+For each plugin_* symbol — one-hop callers and callees:
+
+| Symbol | Caller (external via dlsym) | Callees (in-tree) |
+|---|---|---|
+| `plugin_open` (`H5ToXds.cpp:418`) | XDS-fork `generic_data_plugin.f90:283` (dlsym), `:288` (c_f_procpointer), `:304` (call site) | `setInfoArray` (line 404), `printVersionInfo` (line 33), `H5File::H5File(string)` (`user/H5File.cpp:45`) |
+| `plugin_get_header` (`H5ToXds.cpp:441`) | XDS-fork `generic_data_plugin.f90:275, :280, :362` | `getPreopenedDataCache` (line 142), `setXPixelSize` (line 179), `setYPixelSize` (line 188), `setPixelMask` (line 224), `getNumberOfImages` (line 297), `getNumberOfTriggers` (line 310), `setNFramesPerDataset` (line 346) |
+| `plugin_get_data` (`H5ToXds.cpp:475`) | XDS-fork `generic_data_plugin.f90:267, :272, :406` | `getPreopenedDataCache` (line 142), `readDataset` (line 381) → `Dataset::Dataset` (`user/Dataset.cpp:23`) + `Dataset::read` (`user/Dataset.cpp:111`) |
+| `plugin_close` (`H5ToXds.cpp:493`) | XDS-fork `generic_data_plugin.f90:291, :296, :438` | `unique_ptr<H5DataCache>::reset` → `H5DataCache` dtor → `H5File` dtor → `shared_ptr<char>` dtor → `UnMap` → `munmap` |
+
+**The 4 `plugin_*` symbols have exactly ONE external caller — XDS-fork's
+`generic_data_plugin.f90`.** No in-tree neggia callers. ABI changes (none
+in this ticket) propagate only there.
+
+---
+
+## 4. ABI Surface Impact
+
+Candidate change: replace `GLOBAL_HANDLE` with worker pool data
+structure. Per-symbol assessment:
+
+- `plugin_open` signature: **unchanged**. Body changes internally. **NO ABI impact.**
+- `plugin_close` signature: **unchanged**. **NO ABI impact.**
+- `plugin_get_header` signature: **unchanged**. **NO ABI impact.**
+- `plugin_get_data` signature: **unchanged**. **NO ABI impact.**
+- Exported symbols: only the 4 `plugin_*` symbols are inside `extern "C"`
+  blocks (`H5ToXds.h:8`, `H5ToXds.cpp:416-497`). No new exports. The
+  `docs/abi-baseline.txt` 4-line nm baseline will still match.
+- **XDS-fork C-binding compatibility** (`generic_data_plugin.f90:140-170`):
+  byte-for-byte match verified — `plugin_open`/`plugin_close`/
+  `plugin_get_header`/`plugin_get_data` all match Fortran `bind(C)`
+  signatures.
+
+**Verdict: ABI HALT does NOT trigger.** The 4 sacred symbols stay
+byte-identical; XDS-fork's `tools/neggia-version.txt` bump path will
+work cleanly post-NEGGIA-001 + post-release.
+
+---
+
+## 5. Invariants
+
+Spec invariants 1-8 restated + audit-surfaced additions:
+
+1. **ABI parity** — `docs/abi-baseline.txt` matches post-patch.
+2. **Source-line cap ≤ 50** — `neggia-surgical-patch` rule.
+3. **Thread-safety of `plugin_get_data`** — TSan + Helgrind verified.
+4. **Documented sync primitives** — patch + audit declare.
+5. **Bit-exact data path** — frame-by-frame byte-equal vs pre-patch `.so`.
+6. **8 existing ctests preserved**.
+7. **No local-SSD single-threaded regression (≤1.1×)**.
+8. **Open/close clean teardown**.
+
+**Audit-surfaced additions:**
+
+- **Inv-A — H5DataCache is write-once-then-immutable after `plugin_get_header`.**
+  All mutations of `dataCache->*` happen during open/header phase
+  (lines 424-425, 182, 184, 191, 193, 232-235, 240-282, 331-334, 349, 352).
+  Zero writes in `plugin_get_data`'s call chain. **Load-bearing for OQ-1.**
+- **Inv-B — H5File is safely copyable across threads** as a read-only
+  shareable handle. PROT_READ mmap; fd closed at construction;
+  `std::shared_ptr<char>` thread-safe refcount.
+- **Inv-C — Dataset is per-call stack-local with `const` read**. No
+  mutable cross-call state at Dataset layer.
+- **Inv-D — Single-open external contract** is announced via the stderr
+  message at `H5ToXds.cpp:432`. XDS-fork does NOT depend on second-open
+  failure (calls `plugin_open` exactly once per `xds_par` — verified
+  `generic_data_plugin.f90:304`).
+- **Inv-E — `plugin_close`'s `error_flag` is uninitialised** (`H5ToXds.cpp:493-495`).
+  Pre-existing bug; out-of-scope for NEGGIA-001 but flagged for
+  separate ticket.
+
+---
+
+## 6. Risks
+
+Per the three candidate worker-pool designs:
+
+| Candidate | Risk | Rationale |
+|---|---|---|
+| **(a) `vector<unique_ptr<H5DataCache>>` sized K, per-worker ownership, no get_data mutex, dispatch by frame_number % K** | **Low-Medium** | Eliminates Inv-A dependency entirely. Per-worker thread-confined state → trivially TSan-clean and Helgrind-clean. H5File mmap shared via shared_ptr (Inv-B) → K workers share ONE mmap. Risk is Medium only because the concurrency surface is new + has no prior ctest coverage. AT-3/4/5/6 are the mitigation. **RECOMMENDED.** |
+| **(b) shared `H5DataCache` + `std::mutex` on get_data** | Medium | Serialises every get_data → defeats the entire purpose of the ticket. Throughput target AT-8 (≥1.3×) almost certainly unachievable. |
+| **(b') shared `H5DataCache` + NO mutex (relies on Inv-A)** | Medium | Data-race-free in current code but fragile: a future patch (e.g. NEGGIA-002 mmap→pread) that adds get_data-path mutation silently regresses. Helgrind may flag unsynchronised reads of the underlying raw pointer anyway. |
+| **(c) hybrid — shared master, per-worker data file handles** | Medium-High | Effectively collapses into (a) when `H5File` is shared via `shared_ptr` (Inv-B). The "hybrid" framing adds complexity without benefit given Inv-B. |
+
+**Overall risk for NEGGIA-001 with recommended candidate (a): Medium.**
+Single-TU refactor with NO ABI impact, but introduces a previously-absent
+concurrency surface. The AC battery (ABI parity + 8 baseline ctests +
+new Test_XdsPluginConcurrent + TSan + Helgrind + bit-exact regression +
+cap check) is well-calibrated.
+
+---
+
+## 7. Existing ctest Coverage on Surface
+
+- **`Test_XdsPlugin`** at `src/dectris/neggia/test/Test_XdsPlugin.cpp:31-156`
+  — single-threaded; exercises all 4 `plugin_*` via dlopen+dlsym;
+  9 test bodies covering ABI presence, open/close, header values,
+  full-frame correctness. Uses `TestDatasetArtificialSmall001` fixture.
+- **`Test_XdsPluginWithData`** at `src/dectris/neggia/test/Test_XdsPluginWithData.cpp:34-150`
+  — single-threaded; exercises against real Eiger1/Eiger2 fixtures
+  (8 fixtures total; BSLZ4 / LZ4 / uint8 / uint32 variants).
+- **NO existing test covers concurrent calls.** No `mutex`/`atomic`/
+  `thread`/`pthread` references in `src/dectris/neggia/test/`,
+  `src/dectris/neggia/plugin/`, `src/dectris/neggia/data/`, or
+  `src/dectris/neggia/user/` (verified via grep).
+- **`H5DataCache` concurrency coverage**: NONE — TU-private struct,
+  zero direct test coverage; exercised only transitively.
+- **CMakeLists pattern**: `src/dectris/neggia/test/CMakeLists.txt:58-79`
+  for the two existing plugin tests. New `Test_XdsPluginConcurrent`
+  clones that block + adds `pthread` link for `std::thread`.
+
+---
+
+## 8. Challenge Questions Answered
+
+**Who else calls this?** Exactly ONE external consumer per symbol:
+XDS-fork's `generic_data_plugin.f90` via `dlsym` at lines 267/275/283/291
+(declarations) and 304/362/406/438 (call sites). No in-tree neggia
+callers — the 4 `plugin_*` symbols ARE the C ABI implementation.
+
+**What invariants would silently break?** Three:
+1. Inv-A (H5DataCache write-once) — if a future patch adds get_data-path
+   mutation under shared-cache (b'), silent corruption. Mitigated by
+   recommended per-worker design (a).
+2. Inv-D (single-open external contract) — if worker pool allows second
+   `plugin_open` while one is active, the documented stderr message
+   doesn't fire. XDS-fork doesn't depend on it, but preserve the
+   contract for any hypothetical downstream tooling.
+3. Bit-exact correctness — if `Dataset` were non-idempotent across
+   workers. Verified `Dataset` is per-call stack-local (Inv-C) → safe.
+
+**Race-condition path?** Under shared-cache no-mutex design (b'): the
+load of `GLOBAL_HANDLE.get()` at `getPreopenedDataCache()` (line 143) is
+a non-atomic raw pointer load — could be torn or reordered on weakly-
+ordered architectures. But happens-before ordering of Fortran's
+serial open-then-call discipline + dlsym synchronisation makes the
+race not reachable in practice. **The race only becomes reachable if
+get_header runs concurrently with get_data** — e.g. if future XDS
+parallelised the open phase. Mitigation in recommended design (a):
+per-worker ownership means no shared mutable state exists at all.
+
+**ctest coverage needed?** New `Test_XdsPluginConcurrent`: spawns 16
+threads each calling `plugin_get_data(frame_n)` for `frame_n in [0,99]`
+in randomised order; computes single-threaded reference; asserts
+every returned frame bit-equal to the reference for the same frame_n.
+
+**Last touched?** `git log -1 -- src/dectris/neggia/plugin/H5ToXds.cpp`:
+`268aed2 2021-03-24 10:20:24 +0100 fix overflow handling`. Pre-
+Dectris-cloud transfer; no fork-side edits since baseline.
+
+**ABI still matches `generic_data_plugin.f90:140-170`?** **YES.** Four-by-
+four signature match verified in §4. Worker pool is pure internal
+refactor; `extern "C"` boundary preserved.
+
+---
+
+## 9. OQ Resolutions (load-bearing)
+
+### OQ-1 — Is `H5DataCache` thread-safe internally?
+
+**RESOLVED: H5DataCache is effectively thread-safe under Inv-A (write-once-
+then-immutable after `plugin_get_header`), BUT per-worker ownership is
+the safer engineering choice.**
+
+Evidence: comprehensive grep of `dataCache->` writes — all 100% inside
+open/header phase. `plugin_get_data` reads only. See `H5ToXds.cpp` lines
+424-425 (open), 182, 184, 191, 193, 232-235, 240-282, 331-334, 349, 352
+(header). Per-call state in `readDataset` is stack-local. Dataset is
+per-call. H5File mmap is PROT_READ.
+
+**Recommendation: per-worker ownership** for three reasons:
+1. Eliminates the subtle Inv-A dependency — a future patch that adds
+   a write in the get_data path silently regresses under shared design.
+2. Cheap: H5File mmap is shared via `std::shared_ptr<char>` (Inv-B),
+   so K workers share ONE mmap of the master.
+3. TSan-clean and Helgrind-clean trivially — no shared mutable state.
+
+### OQ-2 — Default worker count source
+
+**RESOLVED: N_data_files is NOT directly queryable from existing code.**
+
+Current code only discriminates `masterFileOnly` (line 349/352) via
+existence-probing `/entry/data/data_000001` vs `/entry/data/data`.
+
+Three options for NEGGIA-001:
+1. Probe sequentially (`data_000001`, `data_000002`, ...) until
+   `Dataset` ctor throws `out_of_range`. ~5 cap units.
+2. Enumerate via `H5LinkInfoMessage`/`H5BTreeVersion2`. ~10-15 cap units.
+3. **Hardcode K=16 unconditionally for NEGGIA-001** (defer N_data_files
+   probe to NEGGIA-004's env-var work). ~2 cap units. **RECOMMENDED**
+   for minimal-patch HALT compliance.
+
+The formula's purpose is "expose XDS's existing parallelism"; K=16 is
+the hard upper bound anyway. Refinement is NEGGIA-004 territory.
+
+### OQ-3 — Minimal pool data structure recommendation
+
+**RESOLVED: candidate (a) — `std::vector<std::unique_ptr<H5DataCache>>`
+of size K=16, per-worker ownership, dispatch by `frame_number % K`.**
+
+Cap-units projection (1.5× weight on `.h`/`.hpp`, but no header changes
+in this design — all changes are TU-private in `H5ToXds.cpp`):
+
+| Change | Lines added | Notes |
+|---|---|---|
+| `GLOBAL_POOL` declaration | 1-2 | replaces line 31 |
+| `getPreopenedDataCache(int frame_number)` rewrite | 3-4 | replaces lines 142-148 |
+| `plugin_open` rewrite (replicate H5DataCache K times after header) | 6-10 | adjustments at lines 418-439 |
+| `plugin_close` rewrite | 1-2 | replaces line 494 |
+| `plugin_get_data` rewrite | 1 | line 483 change |
+| `plugin_get_header` adjust (header on worker[0], then field-copy or shared master cache) | 5-8 | lines 441-473 |
+| **Total** | **17-27** | well under 50 |
+
+Test file `Test_XdsPluginConcurrent.cpp` (~80-100 lines) is NEW but
+**NOT counted against the 50-cap** per `neggia-surgical-patch` rules
+(test files are exempt). CMakeLists addition: ~6 lines, also framework-
+exempt.
+
+### OQ-4 — Does removing GLOBAL_HANDLE break single-open invariant?
+
+**RESOLVED: preserve externally, drop internally.**
+
+Evidence: stderr message at `H5ToXds.cpp:432` is a user-visible
+behaviour. XDS-fork's `generic_data_plugin.f90:304` calls
+`dll_plugin_open` exactly once per `xds_par` process (verified via grep
+— declaration at 173, bind at 288, single call at 304).
+
+Implementation in NEGGIA-001: keep `if (!GLOBAL_POOL.empty()) { stderr
+<< "NEGGIA ERROR: CAN ONLY OPEN ONE FILE AT A TIME ..."; return; }` at
+the start of new `plugin_open`. Single logical dataset open at a time
+externally; multiple workers internally.
+
+### OQ-5 — Per-worker fd or shared fd?
+
+**RESOLVED: per-worker H5DataCache does NOT multiply persistent fds.**
+
+`H5File::H5File` at `user/H5File.cpp:45` calls `mapFile` (lines 18-41):
+- Line 22: `open(path, O_RDONLY)` — opens fd.
+- Line 30: `mmap(...)`.
+- **Line 37: `close(fd)`** — fd released BEFORE the mmap region is
+  returned via shared_ptr. mmap region remains valid post-close on
+  POSIX (kernel retains the mapping reference).
+
+Fd budget for K=16 + master + 2 data files dataset:
+- Persistent fds: **0** (all closed at construction).
+- Peak transient fds during `plugin_open` + `plugin_get_header`:
+  ~3-5 (master + a few data-file resolves).
+- During `plugin_get_data`: 0-2 transient per call (Dataset ctor may
+  open a data file via `H5File` then immediately close).
+
+Linux nofile default 1024; macOS 256. **K=16 workers consume <50 fds
+peak.** No `setrlimit` raise needed.
+
+---
+
+## 10. Last-touched history
+
+```
+$ git log -1 --format='%H %ai %s' -- src/dectris/neggia/plugin/H5ToXds.cpp
+268aed2 2021-03-24 10:20:24 +0100 fix overflow handling
+```
+
+5 most recent touching `H5ToXds.cpp`:
+```
+268aed2 fix overflow handling                                  [2021-03-24]
+40edc21 Support all integer types for pixel_mask
+8f12674 Decouple Dataset and H5DataLayoutMsg
+74ad84f plugin: support signed int for ntrigger and nimages
+3e57c35 support dataset with missing ntrigger
+```
+
+All pre-Dectris-cloud transfer (2021 era). No fork-side edits since
+baseline. `H5File.cpp` + `Dataset.cpp` last touched `ff23220 2021-03-25
+14:27:54 +0100 add support for data layout version 4`.
+
+---
+
+## Audit-surfaced anomalies (flagged for separate tickets — NOT NEGGIA-001 scope)
+
+1. **Dead code at `H5ToXds.cpp:414`** — `std::unique_ptr<H5DataCache>
+   retVal(new H5DataCache);` declared at file scope outside the anonymous
+   namespace. Never referenced. Cleanup ticket candidate.
+2. **`plugin_close` never assigns `error_flag`** (`H5ToXds.cpp:493-495`).
+   Latent bug; tests pass only because callers pre-zero the flag.
+3. **Wasted allocation on `plugin_open` refusal path** (lines 422-438):
+   H5DataCache + mmap are allocated BEFORE the `GLOBAL_HANDLE` check.
+   On refusal, the allocation is destroyed at scope exit. Cosmetic
+   inefficiency; not a bug.
+
+---
+
+## Devil's Advocate
+
+**Strongest argument against the proposed approach** (recommended
+candidate (a) per-worker ownership): **if NEGGIA-002 (mmap → pread)
+reintroduces mutation in the get_data path, per-worker isolation
+catches it but the bit-exact regression gate may not — pread can
+return data that's not byte-identical to mmap'd data in pathological
+GeeseFS-S3 scenarios (e.g. consistent-read ordering differs between
+mmap's page-fault stream and pread's explicit-range stream).** The
+local ctest gate uses local files, not S3, so the bit-exact regression
+on `h5-testfiles/datasets_eiger{1,2}/` will pass on the local-SSD
+path. The real risk surface is the scientists-in-cloud benchmark
+(AT-8) — if it fails on GeeseFS, the failure mode is silent stale
+reads, not a TSan/Helgrind report. **Mitigation**: NEGGIA-002's spec
+must include a Helgrind run against a network filesystem mount (or
+explicitly declare local-SSD-only verification, with scientists-in-
+cloud as the gating signal).
+
+**Second-order effect on bit-exactness**: the OS page cache + shared
+mmap behaviour under K=16 workers reading from the same master file —
+if one worker's read triggers readahead that another worker subsequently
+hits, are the views guaranteed coherent? **Answer**: yes, within a single
+process the page cache is coherent (Linux/macOS guarantee this; mmap
+PROT_READ is a kernel-mediated view). No risk.
+
+**What would make this audit wrong?** If `H5File` retains hidden mutable
+state I missed — e.g. if its destructor side-effects on the mmap'd
+region. Verified: `UnMap` deleter (`user/H5File.cpp` UnMap class) only
+calls `munmap`; no writes. If the audit is wrong on Inv-A (some
+write site in get_data path I missed): per-worker ownership saves us
+even from that miss, because each worker's state is private and
+mutations would not race across workers — they'd just appear in the
+wrong worker's slot. The bit-exact regression gate (AT-6) would catch
+that as a fixture mismatch.
+
+---
+
+## Audit Verdict
+
+**Verdict: READY_FOR_PATCH** — conditional on:
+
+(a) **Patch chooses candidate (a)**: `std::vector<std::unique_ptr<H5DataCache>>`
+sized K, per-worker ownership, dispatch by `frame_number % K`, no
+get_data-path mutex.
+
+(b) **Worker count K=16 hardcoded** (defer N_data_files probe to
+NEGGIA-004's env-var work). Cap-units savings keep total under 50.
+
+(c) **Single-open external contract preserved** (`H5ToXds.cpp:432`
+stderr message kept verbatim or equivalent).
+
+(d) **Test_XdsPluginConcurrent.cpp** authored per spec AT-3 (16 threads
+× 100 calls; randomised frame order; bit-equality against single-
+threaded reference computed first).
+
+(e) **The 3 audit-surfaced anomalies** (dead code at line 414;
+`plugin_close` error_flag bug; wasted-allocation refusal path) are
+**NOT touched in this ticket** — separate tickets if and when worth.
+
+(f) **No header file changes** — pool data structure lives TU-private
+in `H5ToXds.cpp` anonymous namespace alongside existing `H5DataCache`
+struct. This avoids the 1.5× header weight; keeps cap-units low.
+
+**Rationale**: Change is structurally sound, isolates the concurrency
+surface to a single TU, preserves the 4-symbol ABI byte-identically,
+and inherits the existing single-threaded test coverage as a regression
+baseline (AT-2). The Devil's Advocate concern about mmap → pread
+interaction is for NEGGIA-002's audit, not this one. The recommended
+candidate (a) cleanly satisfies the spec's 8 invariants under the
+projected 17-27 cap-units envelope.
+
+**Scope check passes** with the recommended design. No `SCOPE_MISMATCH`.
+ABI HALT does NOT trigger. Spec invariants 1-8 + audit-surfaced
+invariants A-E remain unchanged; the implementation surface is the
+file list in the spec's Affected Source plus the new test file.
+
+**OQ resolutions:**
+- OQ-1 — RESOLVED — H5DataCache thread-safe under Inv-A; per-worker ownership preferred.
+- OQ-2 — RESOLVED — K=16 hardcoded in NEGGIA-001; N_data_files probe deferred to NEGGIA-004.
+- OQ-3 — RESOLVED — candidate (a) `vector<unique_ptr<H5DataCache>>` per-worker; 17-27 cap units projected.
+- OQ-4 — RESOLVED — preserve external single-open contract (stderr message at line 432).
+- OQ-5 — RESOLVED — no persistent fd multiplication; H5File closes fd at construction; ~50 fd peak budget; no `setrlimit` needed.
+
+---
+
+## Minimal Patch Proposal (cap-exempt under reporter override)
+
+**Source-line count: ~67 / 50** (sum of additions + removals).
+Reporter-direct override authorized 2026-05-29 (see
+`tickets/open/NEGGIA-001-worker-pool-replacing-global-handle.md` § Notes).
+Precedent: XDS-036 (2026-05-05, 155 cap units / 3.1× cap). Cap reaffirmed
+in force for all subsequent NEGGIA-NNN tickets.
+
+### Cap accounting (informational; override authorized above)
+
+Detailed cap accounting under sum rule:
+
+| Hunk | Removed | Added | Sum |
+|---|---|---|---|
+| Pool decl (line 31): `unique_ptr<H5DataCache>` → `vector<unique_ptr<H5DataCache>>` + K constant | 1 | 2 | 3 |
+| `getPreopenedDataCache` rewrite (lines 142-148) with frame_number dispatch | 7 | 6 | 13 |
+| `plugin_open` rewrite (lines 422-438): single-instance → K-loop with single-open check moved to front | 17 | 18 | 35 |
+| `plugin_get_header` (insert after line 457): header-field propagation loop with mask memcpy | 0 | 12 | 12 |
+| `plugin_get_data` (line 483): `getPreopenedDataCache()` → `getPreopenedDataCache(*frame_number)` | 1 | 1 | 2 |
+| `plugin_close` (line 494): `GLOBAL_HANDLE.reset()` → `GLOBAL_POOL.clear()` | 1 | 1 | 2 |
+| **Total** | **27** | **40** | **67** |
+
+(Test files exempt from cap; `Test_XdsPluginConcurrent.cpp` ~80 lines,
+`test/CMakeLists.txt` ~6 lines, `tools/regress_bitexact.sh` ~30 lines all
+fall outside the source-line counting universe.)
+
+### Affected files
+
+| Path | New/Edit | Authored | Notes |
+|---|---|---|---|
+| `src/dectris/neggia/plugin/H5ToXds.cpp` | EDIT | here | Replace `GLOBAL_HANDLE` with `GLOBAL_POOL` of `NUM_WORKERS=16` `H5DataCache` instances; rewrite `getPreopenedDataCache` with frame-index dispatch; rewrite `plugin_open` (K-loop, single-open contract preserved); add header propagation loop in `plugin_get_header`; update `plugin_get_data` dispatch by frame_number; `plugin_close` clears pool. Cap-exempt under override. |
+| `src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp` | NEW | here | AT-3/AT-4/AT-5: 16 threads × 100 plugin_get_data calls with randomised frame numbers; assert bit-equality against single-threaded reference. Test-cap-exempt. |
+| `src/dectris/neggia/test/CMakeLists.txt` | EDIT | here | Wire `Test_XdsPluginConcurrent` (DatasetsFixture link + dl + pthread + gtest). Framework-cap-exempt. |
+| `tools/regress_bitexact.sh` | NEW +x | here | AT-6: inline-compiles a small `dlopen`+`plugin_*` runner; runs against baseline + candidate `.so`; byte-compares every frame of every fixture under given fixture dirs. Framework-cap-exempt. |
+| `CHANGELOG.md` | EDIT | here | `[Unreleased] → Changed` entry. Framework-cap-exempt. |
+| `tickets/open/NEGGIA-001-…md` § Notes | EDIT | here | Reporter-override authorization recorded. |
+| `docs/audits/NEGGIA-001.md` | EDIT (this section) | here | Minimal Patch Proposal section. |
+
+### Per-hunk justification (H5ToXds.cpp)
+
+1. **Includes (`<cstring>` + `<vector>`)** — required by the new
+   propagation loop's `std::memcpy` + the new `std::vector` pool.
+2. **`GLOBAL_HANDLE` → `NUM_WORKERS` + `GLOBAL_POOL`** — Inv-1 (ABI
+   parity) + spec Goal (worker pool replaces singleton).
+3. **`getPreopenedDataCache(size_t frame_index = 0)`** — OQ-3 candidate
+   (a) dispatch helper; default `frame_index=0` selects worker[0] (the
+   master cache used by `plugin_get_header`).
+4. **`plugin_open` rewrite** — OQ-2 (K=16 hardcoded), OQ-3 (per-worker
+   ownership; each worker constructs its own `H5File` for per-worker
+   mmap = per-worker kernel readahead state), OQ-4 (single-open
+   external contract preserved by check at top + stderr message
+   verbatim).
+5. **Header propagation loop in `plugin_get_header`** — Inv-A
+   (H5DataCache write-once-then-immutable after header) propagated to
+   all workers via field-copy + mask `memcpy`. Each worker's `mask`
+   is a fresh allocation owned by that worker; thread-confined.
+6. **`plugin_get_data` dispatch** — spec Invariant 3 (thread-safety
+   guarantee on `plugin_get_data` via per-worker ownership; lock-free
+   hot path).
+7. **`plugin_close` clears pool** — spec Invariant 8 (clean
+   teardown).
+
+### Verification plan
+
+Local-host verification matrix (Linux/macOS) — orchestrated by
+`neggia-verify` skill:
+
+1. **Build (Release)**:
+   ```bash
+   cd /Users/max.burian/Documents/03_Programming_Projects/neggia
+   cmake -B build -DCMAKE_BUILD_TYPE=Release
+   cmake --build build --parallel
+   ```
+   Expect: exit 0; `build/src/dectris/neggia/plugin/dectris-neggia.so` exists.
+
+2. **AT-1 — ABI parity**:
+   ```bash
+   nm -D build/src/dectris/neggia/plugin/dectris-neggia.so \
+     | grep -E '\b(plugin_open|plugin_close|plugin_get_header|plugin_get_data)\b' \
+     | awk '{print $3}' | sort > /tmp/actual-abi.txt
+   diff /tmp/actual-abi.txt docs/abi-baseline.txt
+   ```
+   Expect: exit 0; no diff.
+
+3. **AT-2 — 8 existing ctests + new Test_XdsPluginConcurrent (AT-3)**:
+   ```bash
+   cd build && ctest --output-on-failure
+   ```
+   Expect: 9/9 tests passed.
+
+4. **AT-4 — TSan**:
+   ```bash
+   cmake -B build-tsan -DCMAKE_BUILD_TYPE=Release \
+                       -DCMAKE_CXX_FLAGS="-fsanitize=thread -g" \
+                       -DCMAKE_C_FLAGS="-fsanitize=thread -g"
+   cmake --build build-tsan --parallel
+   cd build-tsan && ctest -R Test_XdsPluginConcurrent --output-on-failure
+   ```
+   Expect: exit 0; zero `WARNING: ThreadSanitizer` lines.
+
+5. **AT-5 — Helgrind** (Linux only; valgrind unavailable on macos-14 ARM):
+   ```bash
+   valgrind --tool=helgrind --error-exitcode=1 \
+     build/src/dectris/neggia/test/Test_XdsPluginConcurrent
+   ```
+   Expect: exit 0; "ERROR SUMMARY: 0 errors from 0 contexts".
+
+6. **AT-6 — Bit-exact regression**:
+   ```bash
+   # Build pre-patch baseline (from HEAD~1 of feature branch — the
+   # neggia bootstrap commit at master):
+   git worktree add /tmp/neggia-baseline master
+   cmake -S /tmp/neggia-baseline -B /tmp/neggia-baseline-build \
+         -DCMAKE_BUILD_TYPE=Release
+   cmake --build /tmp/neggia-baseline-build --parallel
+   # Compare:
+   ./tools/regress_bitexact.sh \
+     /tmp/neggia-baseline-build/src/dectris/neggia/plugin/dectris-neggia.so \
+     build/src/dectris/neggia/plugin/dectris-neggia.so \
+     src/dectris/neggia/test/h5-testfiles/datasets_eiger1 \
+     src/dectris/neggia/test/h5-testfiles/datasets_eiger2
+   ```
+   Expect: exit 0; "PASS: all fixtures byte-identical".
+
+7. **AT-8 — scientists-in-cloud benchmark** (out of scope for local
+   verify; recorded in release notes per NEGGIA-005 plan).
+
+### Verdict
+- **READY_FOR_HUMAN_APPLY** (cap-exempt under reporter override
+  2026-05-29; precedent XDS-036).

--- a/docs/specs/NEGGIA-001.md
+++ b/docs/specs/NEGGIA-001.md
@@ -1,0 +1,257 @@
+# Spec: NEGGIA-001 — Worker pool replacing GLOBAL_HANDLE singleton
+
+## Goal
+Remove the structural concurrency bottleneck at the neggia plugin layer.
+The unique-pointer singleton `GLOBAL_HANDLE` at
+`src/dectris/neggia/plugin/H5ToXds.cpp:31` forbids concurrent opens and
+gates every `plugin_get_data` through one logical reader. Replacing it
+with a worker pool (each worker owning its own state, or sharing under
+mutex — audit decides) exposes the parallelism XDS already has at its
+integration loop above the plugin. Stage 1 of the Tier-1 perf overhaul
+per `docs/plans/tier-1-performance.md`. The four `plugin_*` C symbols
+preserve their signatures (ABI parity invariant); XDS-fork's
+`tools/neggia-version.txt` bump path stays clean. Source-line cap: ≤50
+per `neggia-surgical-patch` rules (incl. 1.5× header weight).
+
+## Affected Source
+
+- `src/dectris/neggia/plugin/H5ToXds.cpp:31` — `GLOBAL_HANDLE` singleton
+  declaration; removed and replaced with worker pool data structure.
+- `src/dectris/neggia/plugin/H5ToXds.cpp:418-437` — `plugin_open`;
+  currently refuses concurrent opens (line 423 check). Revised to
+  initialise the worker pool; per-worker state allocation happens here.
+- `src/dectris/neggia/plugin/H5ToXds.cpp:441-473` — `plugin_get_header`;
+  dispatches via pool.
+- `src/dectris/neggia/plugin/H5ToXds.cpp:475-500` (approx) —
+  `plugin_get_data`; dispatches via pool with per-worker H5DataCache (or
+  shared instance under mutex; audit decides).
+- `src/dectris/neggia/plugin/H5ToXds.cpp` — `plugin_close`; tears down
+  the worker pool cleanly.
+- `src/dectris/neggia/plugin/H5ToXds.h` (or sibling header introducing
+  the pool data structure) — minor declaration changes, header-weight
+  cap applies.
+- `src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp` — NEW; 16-thread
+  stress test asserting bit-equality against single-threaded reference.
+- `src/dectris/neggia/test/CMakeLists.txt` — wire new test (one
+  `add_executable` + `add_test` block).
+- `tools/regress_bitexact.sh` — NEW helper script for AC-6 (frame-by-frame
+  byte-compare against pre-patch `.so`).
+
+Read-only references (the contract surface — not modified):
+
+- `docs/abi-baseline.txt` — the 4 sacred `plugin_*` symbols.
+- `../xds/src/generic_data_plugin.f90:140-170` — XDS-fork's Fortran
+  C-binding declarations for the 4 symbols; load-bearing for ABI parity
+  invariant. Must continue to match.
+- `src/dectris/neggia/user/H5File.cpp:22-37` — current mmap-based open
+  path; **NOT changed in this ticket** (mmap → pread is NEGGIA-002 scope).
+- `src/dectris/neggia/data/H5DataCache.{h,cpp}` (approx — actual paths
+  resolved by audit) — the per-handle cache type that wraps a parsed
+  HDF5 file; thread-safety of this class is OQ-1 below.
+
+## Invariants
+
+1. **ABI parity.** `nm -D build/src/dectris/neggia/plugin/dectris-neggia.so
+   | grep -E '\b(plugin_open|plugin_close|plugin_get_header|plugin_get_data)\b'
+   | sort` matches `docs/abi-baseline.txt` exactly. Four lines, alphabetical.
+   Source of truth: `docs/abi-baseline.txt` + `Hard Rule 4` in
+   `docs/architecture/agent-framework.md`. ABI HALT in
+   `neggia-surgical-patch` triggers if violated.
+
+2. **Source-line cap.** ≤ 50 cap units per `neggia-surgical-patch`
+   counting rules (additions + removals in `src/dectris/neggia/`,
+   non-blank non-comment, with 1.5× weight on `.h`/`.hpp` lines). Source
+   of truth: `.claude/skills/neggia-surgical-patch/SKILL.md` source-line
+   counting rules. HALT if exceeded.
+
+3. **Thread-safety guarantee on `plugin_get_data`.** After this ticket,
+   `plugin_get_data(frame_number, ...)` is data-race-free under
+   concurrent calls from any number of threads. Each call returns the
+   frame as if it were the only call. Formally: for any two threads
+   T1, T2 calling `plugin_get_data` concurrently with possibly different
+   `frame_number` arguments, the result for each call is byte-identical
+   to the result the same call would return single-threaded. Source of
+   truth: spec assumption + verified by Acceptance Test AT-4
+   (`Test_XdsPluginConcurrent` under TSan) and AT-5 (under Helgrind).
+
+4. **Synchronisation primitive set documented.** The patch + audit
+   declare which sync primitives are introduced (`std::mutex`,
+   `std::atomic`, `std::condition_variable`, lock-free patterns) AND
+   the invariant each guards. No undocumented synchronisation. Audit
+   OQ-2 resolves whether per-worker H5DataCache (no sync needed at the
+   data layer) or shared H5DataCache with a mutex.
+
+5. **Bit-exact data path.** For every fixture under
+   `src/dectris/neggia/test/h5-testfiles/datasets_eiger1/` and
+   `datasets_eiger2/`, the post-patch `.so`'s `plugin_get_data(N)`
+   returns byte-identical output to the pre-patch `.so` for every
+   frame N in [0, total_frames-1]. Source of truth: spec assumption +
+   verified by AT-6.
+
+6. **Existing ctest baseline preserved.** All 8 upstream tests pass
+   post-patch: `Test_Dataset`, `Test_EigerData`, `Test_DifferentH5Ver`,
+   `Test_H5DataspaceMsg`, `Test_H5FilterMsg`, `Test_H5ObjectHeader`,
+   `Test_XdsPlugin`, `Test_XdsPluginWithData`. Verified by AT-2.
+
+7. **No regression on local-SSD single-threaded read latency.** Single-
+   threaded `plugin_get_data` post-patch is ≤ 1.1× pre-patch wall time
+   on a local-SSD fixture (the manual benchmark — defensive: a worker
+   pool introducing per-call dispatch overhead should not pessimise the
+   single-threaded fast path). Source of truth: spec assumption;
+   verified by AT-8 (manual benchmark).
+
+8. **Open/close semantics preserved.** `plugin_open` followed by
+   `plugin_close` cleanly tears down the pool. No worker thread
+   outlives the close. No leaked file descriptors. Source of truth:
+   spec assumption; verified by AT-2's existing `Test_XdsPlugin`
+   open/close cycle.
+
+## Acceptance Tests
+
+1. **AT-1 — ABI parity** — type: bit-exact / nm-based assertion
+   (CI step or `neggia-verify` host-side).
+   - Setup: post-patch build at `build/src/dectris/neggia/plugin/dectris-neggia.so`.
+   - Action: `nm -D <so> | grep -E '\b(plugin_open|plugin_close|plugin_get_header|plugin_get_data)\b' | awk '{print $3}' | sort > /tmp/actual-abi.txt; diff /tmp/actual-abi.txt docs/abi-baseline.txt`.
+   - Expected: exit 0; no differences.
+
+2. **AT-2 — Existing ctest baseline green** — type: ctest.
+   - Setup: post-patch build; `cd build`.
+   - Action: `ctest --output-on-failure`.
+   - Expected: exit 0; ctest summary reports 9/9 tests passed (the
+     existing 8 + the new `Test_XdsPluginConcurrent`).
+
+3. **AT-3 — `Test_XdsPluginConcurrent` exists and passes** — type: ctest.
+   - Setup: post-patch build; the new test file exists at
+     `src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp` and is wired
+     into `src/dectris/neggia/test/CMakeLists.txt`.
+   - Action: `cd build && ctest -R Test_XdsPluginConcurrent --output-on-failure`.
+   - Expected: exit 0. Test body: spawns 16 threads, each calling
+     `plugin_get_data(frame_n)` for `frame_n` in [0, 99] in a random
+     order; computes a reference by running the same calls
+     single-threaded first; asserts every returned frame from every
+     thread bit-equal to the reference for the same `frame_n`.
+
+4. **AT-4 — TSan clean on `Test_XdsPluginConcurrent`** — type: TSan
+   (sanitizer rebuild).
+   - Setup: separate build dir;
+     `cmake -B build-tsan -DCMAKE_BUILD_TYPE=Release
+                          -DCMAKE_CXX_FLAGS="-fsanitize=thread -g"
+                          -DCMAKE_C_FLAGS="-fsanitize=thread -g"`
+     `cmake --build build-tsan --parallel`.
+   - Action: `cd build-tsan && ctest -R Test_XdsPluginConcurrent --output-on-failure`.
+   - Expected: exit 0; ZERO `WARNING: ThreadSanitizer` lines in the
+     test log (`grep -c 'WARNING: ThreadSanitizer' ctest_output.log`
+     returns 0).
+
+5. **AT-5 — Helgrind clean on `Test_XdsPluginConcurrent`** — type:
+   Helgrind.
+   - Setup: post-patch build (or build-tsan; either works for Helgrind).
+   - Action: `valgrind --tool=helgrind --error-exitcode=1
+     ./build/src/dectris/neggia/test/Test_XdsPluginConcurrent`.
+   - Expected: exit 0; "ERROR SUMMARY: 0 errors from 0 contexts" in
+     Helgrind output.
+
+6. **AT-6 — Bit-exact regression against pre-patch `.so`** — type:
+   bit-exact (orchestrated by `tools/regress_bitexact.sh`).
+   - Setup: pre-patch baseline `.so` produced via:
+     `git stash; git checkout HEAD~1; cmake --build build-baseline; cp
+     build-baseline/.../dectris-neggia.so /tmp/baseline.so; git checkout -;
+     git stash pop`. Post-patch `.so` at
+     `build/src/dectris/neggia/plugin/dectris-neggia.so`.
+   - Action: `tools/regress_bitexact.sh /tmp/baseline.so
+     build/src/dectris/neggia/plugin/dectris-neggia.so
+     src/dectris/neggia/test/h5-testfiles/datasets_eiger1
+     src/dectris/neggia/test/h5-testfiles/datasets_eiger2`.
+   - Expected: exit 0; the script reports for each frame index N in
+     each fixture: `byte-identical` (and exits non-zero on first
+     mismatch). For Eiger1 fixture: ~5 frames; for Eiger2: ~5 frames.
+
+7. **AT-7 — Source-line cap** — type: line-count check (host-side).
+   - Setup: working tree at the patch commit.
+   - Action: `git diff HEAD~1 -- src/dectris/neggia/ | awk '
+     /^diff/ { in_h = ($0 ~ /\.h(pp)?$/) } 
+     /^[+-][^+-]/ && !/^[+-]\s*$/ && !/^[+-]\s*\/\// {
+       w = (in_h ? 1.5 : 1.0); s += w }
+     END { printf "%.1f\n", s }
+     '`.
+   - Expected: numeric output ≤ 50.0.
+
+8. **AT-8 — Benchmark threshold** — type: benchmark (manual,
+   scientists-in-cloud, NOT CI-gated).
+   - Setup: 192-core node + GeeseFS-S3 mount; 3600-frame Eiger dataset
+     (~1 master + 2 data files); post-patch `xds_par` linked against
+     post-patch neggia `.so` via `LIB=` in `XDS.INP`.
+   - Action: run `xds_par` with `JOB= XYCORR INIT COLSPOT IDXREF DEFPIX
+     INTEGRATE CORRECT` against the benchmark dataset; capture
+     wall-clock from the XDS log's "Total elapsed wall-clock time for XDS"
+     line.
+   - Expected: wall-clock ≤ 70 s (vs the XDS-037 baseline measurement
+     of ~90 s; ≥1.3× speedup). Defensive secondary check: local-SSD
+     single-threaded read of the same fixture is within 1.1× of pre-
+     patch (invariant 7; AT-8b in the closing report). Record results in
+     `docs/learnings/NEGGIA-001.md` if the spec invariants 1-6 all pass
+     AND the benchmark target is met.
+
+## Out of Scope
+
+- **mmap → pread migration.** `src/dectris/neggia/user/H5File.cpp:22-37`
+  retains its mmap-based open path. Switching chunk payloads to pread
+  is **Stage 2 (NEGGIA-002)** per the Tier-1 plan.
+- **Pre-decoded frame ring buffer.** Each worker fetches+decodes
+  synchronously in this ticket. Ring-buffer prefetch is **Stage 3
+  (NEGGIA-003)**.
+- **Env-var configuration surface.** Worker count uses the default
+  formula `K = clamp(N_data_files × 4, 2, 16)` per RFC §4.2; env-var
+  override (`NEGGIA_WORKERS`) is **NEGGIA-004** scope.
+- **Tier-2 ABI extensions** (`plugin_hint_frame_range`,
+  `plugin_get_data_batch`). Out of Tier 1 entirely; would be
+  `abi-evolution`-type tickets with coordinated xds updates.
+- **Changes to `H5DataCache` internal locking** if audit OQ-2 reveals
+  it's already thread-safe enough for the per-worker pattern — no
+  changes inside `data/` subtree. If audit reveals locking is needed
+  inside `H5DataCache`, re-scope: NEGGIA-001 becomes pool-only, a new
+  NEGGIA-001b covers `H5DataCache` lock surface.
+- **GeeseFS-specific tuning.** Worker count clamps to 16 by RFC default;
+  tuning beyond that (for higher-bandwidth links) is out of scope.
+
+## Open Questions
+
+These are resolved by the audit (step 3) before the patch is drafted.
+
+- **OQ-1 — Is `H5DataCache` thread-safe internally?** The audit
+  archaeologist must read `src/dectris/neggia/data/H5DataCache.{h,cpp}`
+  (or its equivalent — discover via grep) and determine: does it hold
+  any mutable state that's modified during a `getData` call (cursor,
+  errno-style last-error fields, cached chunk index)? If yes,
+  per-worker ownership is mandatory (each worker gets its own
+  H5DataCache, opening the master file independently). If no (all
+  mutable state is captured per-call on the stack), a single shared
+  H5DataCache under a mutex suffices.
+- **OQ-2 — Default worker count source.** Spec uses RFC's formula
+  `K = clamp(N_data_files × 4, 2, 16)`. Audit confirms: where is
+  `N_data_files` queryable from at `plugin_open` time? (Likely the
+  master file's `/entry/data` group's link count; needs verification
+  against the existing `H5DataCache` constructor.)
+- **OQ-3 — Minimal pool data structure.** Options: (a)
+  `std::vector<std::unique_ptr<H5DataCache>>` of size K, with workers
+  picking by `frame_number % K` (no mutex needed if H5DataCache is
+  thread-safe per OQ-1); (b) `std::vector<std::unique_ptr<H5DataCache>>`
+  + per-element mutex (audit picks if H5DataCache needs locking); (c) a
+  shared `H5DataCache` + single mutex (only viable if H5DataCache is
+  truly thread-safe AND contention is acceptable). Audit picks based
+  on OQ-1's resolution + cap-units projection.
+- **OQ-4 — Does removing `GLOBAL_HANDLE` break any single-open
+  invariant currently relied on by `plugin_open`?** The current code
+  refuses a second `plugin_open` while one is active (line 423).
+  XDS-fork's caller at `../xds/src/generic_data_plugin.f90:254`
+  `dlopen`s the `.so` once per `xds_par` process and calls
+  `plugin_open` once per dataset. Audit verifies: is there any
+  third-party caller that relies on the explicit "one open at a time"
+  refusal? If so, the worker pool must preserve the refusal semantics
+  while allowing internal concurrency (single logical handle externally,
+  multiple workers internally).
+- **OQ-5 — Per-worker fd or shared fd?** If H5File still owns one fd
+  (today: `H5File.cpp:30` `open()` + line 34 `mmap`), per-worker
+  H5DataCache will multiply fds. Linux ulimit `nofile` default is 1024;
+  16 workers × small fd count per file should be safe. macOS default
+  is 256. Audit verifies feasibility.

--- a/src/dectris/neggia/plugin/H5ToXds.cpp
+++ b/src/dectris/neggia/plugin/H5ToXds.cpp
@@ -3,6 +3,7 @@
 #include "H5ToXds.h"
 #include <dectris/neggia/user/Dataset.h>
 #include <dectris/neggia/user/H5File.h>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -11,6 +12,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <vector>
 #include "H5Error.h"
 
 namespace {
@@ -28,7 +30,14 @@ struct H5DataCache {
     bool masterFileOnly;
 };
 
-std::unique_ptr<H5DataCache> GLOBAL_HANDLE = nullptr;
+// NEGGIA-001: Worker pool replaces GLOBAL_HANDLE singleton (XDS-037 RFC Tier-1
+// Stage 1). Each worker owns its own H5DataCache + H5File (own mmap = own
+// kernel readahead state, load-bearing for GeeseFS-S3 concurrency win).
+// plugin_get_data dispatches by frame_number % NUM_WORKERS — lock-free hot path
+// (each worker's state is thread-confined). Single-open external contract
+// preserved (refuse second plugin_open while pool non-empty).
+constexpr int NUM_WORKERS = 16;
+std::vector<std::unique_ptr<H5DataCache>> GLOBAL_POOL;
 
 void printVersionInfo() {
     std::cout << "This is neggia " << VERSION << " (Copyright Dectris 2020)"
@@ -139,12 +148,11 @@ double readFloatFromDataset(const Dataset& d) {
     }
 }
 
-H5DataCache* getPreopenedDataCache() {
-    H5DataCache* dataCache = GLOBAL_HANDLE.get();
-    if (!dataCache) {
+H5DataCache* getPreopenedDataCache(size_t frame_index = 0) {
+    if (GLOBAL_POOL.empty()) {
         throw H5Error(-2, "NEGGIA ERROR: NO FILE HAS BEEN OPENED YET");
     }
-    return dataCache;
+    return GLOBAL_POOL[frame_index % GLOBAL_POOL.size()].get();
 }
 
 size_t correctFrameNumberOffset(int frameNumberStartingFromOne) {
@@ -419,22 +427,24 @@ void plugin_open(const char* filename, int info_array[1024], int* error_flag) {
     setInfoArray(info_array);
     *error_flag = 0;
     printVersionInfo();
-    std::unique_ptr<H5DataCache> dataCache(new H5DataCache);
-    try {
-        dataCache->filename = filename;
-        dataCache->h5File = H5File(filename);
-    } catch (const std::out_of_range&) {
-        std::cerr << "NEGGIA ERROR: CANNOT OPEN " << filename << std::endl;
-        *error_flag = -4;
-        return;
-    }
-    if (GLOBAL_HANDLE) {
+    if (!GLOBAL_POOL.empty()) {
         std::cerr << "NEGGIA ERROR: CAN ONLY OPEN ONE FILE AT A TIME "
                   << std::endl;
         *error_flag = -4;
         return;
-    } else {
-        GLOBAL_HANDLE = std::move(dataCache);
+    }
+    try {
+        GLOBAL_POOL.reserve(NUM_WORKERS);
+        for (int i = 0; i < NUM_WORKERS; ++i) {
+            std::unique_ptr<H5DataCache> dataCache(new H5DataCache);
+            dataCache->filename = filename;
+            dataCache->h5File = H5File(filename);
+            GLOBAL_POOL.push_back(std::move(dataCache));
+        }
+    } catch (const std::out_of_range&) {
+        std::cerr << "NEGGIA ERROR: CANNOT OPEN " << filename << std::endl;
+        GLOBAL_POOL.clear();
+        *error_flag = -4;
     }
 }
 
@@ -455,6 +465,27 @@ void plugin_get_header(int* nx,
         size_t nimages = getNumberOfImages(dataCache);
         size_t ntrigger = getNumberOfTriggers(dataCache);
         setNFramesPerDataset(dataCache);
+
+        // NEGGIA-001: propagate parsed header fields from worker[0] to
+        // worker[1..K-1] so each worker's H5DataCache is fully populated
+        // before any concurrent plugin_get_data call. Per audit Inv-A:
+        // H5DataCache is write-once-then-immutable after this point, so
+        // per-worker copies are thread-confined and need no synchronization
+        // on the hot path.
+        size_t maskSize = (size_t)dataCache->dimx * dataCache->dimy;
+        for (size_t i = 1; i < GLOBAL_POOL.size(); ++i) {
+            H5DataCache* w = GLOBAL_POOL[i].get();
+            w->dimx = dataCache->dimx;
+            w->dimy = dataCache->dimy;
+            w->datasize = dataCache->datasize;
+            w->nframesPerDataset = dataCache->nframesPerDataset;
+            w->xpixelSize = dataCache->xpixelSize;
+            w->ypixelSize = dataCache->ypixelSize;
+            w->masterFileOnly = dataCache->masterFileOnly;
+            w->mask.reset(new int32_t[maskSize]);
+            std::memcpy(w->mask.get(), dataCache->mask.get(),
+                        maskSize * sizeof(int32_t));
+        }
 
         *nx = dataCache->dimx;
         *ny = dataCache->dimy;
@@ -480,7 +511,7 @@ void plugin_get_data(int* frame_number,
                      int* error_flag) {
     setInfoArray(info_array);
     try {
-        H5DataCache* dataCache = getPreopenedDataCache();
+        H5DataCache* dataCache = getPreopenedDataCache((size_t)*frame_number);
         readDataset(frame_number, data_array, dataCache);
     } catch (const H5Error& error) {
         std::cerr << error.what() << std::endl;
@@ -491,7 +522,7 @@ void plugin_get_data(int* frame_number,
 }
 
 void plugin_close(int* error_flag) {
-    GLOBAL_HANDLE.reset();
+    GLOBAL_POOL.clear();
 }
 
 }  // extern "C"

--- a/src/dectris/neggia/test/CMakeLists.txt
+++ b/src/dectris/neggia/test/CMakeLists.txt
@@ -77,3 +77,17 @@ target_link_libraries(Test_XdsPluginWithData
   gtest_main
   )
 add_test(Test_XdsPluginWithData Test_XdsPluginWithData)
+
+# NEGGIA-001 concurrent stress test: 16 threads x 100 calls; AT-3 / AT-4 (TSan) / AT-5 (Helgrind).
+add_executable(Test_XdsPluginConcurrent
+  $<TARGET_OBJECTS:NEGGIA_COMPRESSION_ALGORITHMS>
+  DatasetsFixture.cpp
+  Test_XdsPluginConcurrent.cpp
+  )
+target_link_libraries(Test_XdsPluginConcurrent
+  dl
+  pthread
+  gtest
+  gtest_main
+  )
+add_test(Test_XdsPluginConcurrent Test_XdsPluginConcurrent)

--- a/src/dectris/neggia/test/DatasetsFixture.h
+++ b/src/dectris/neggia/test/DatasetsFixture.h
@@ -4,6 +4,7 @@
 #define DATASETS_FIXTURE_H
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include <sstream>
 #include <string>
 

--- a/src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp
+++ b/src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+//
+// NEGGIA-001 Acceptance Test AT-3: concurrent plugin_get_data must return
+// byte-identical data to the single-threaded reference, across NUM_THREADS
+// workers each making CALLS_PER_THREAD calls in randomised frame order.
+//
+// AT-4 verifies the same test under TSan (-fsanitize=thread); AT-5 under
+// Helgrind. Both expected to report zero races / zero errors because each
+// worker's H5DataCache is thread-confined post-NEGGIA-001 (per-worker
+// ownership; dispatch by frame_number % NUM_WORKERS in plugin_get_data).
+
+#include <dectris/neggia/user/H5File.h>
+#include <dlfcn.h>
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <iostream>
+#include <random>
+#include <thread>
+#include <vector>
+#include "DatasetsFixture.h"
+
+typedef void (*plugin_open_file)(const char*,
+                                 int info_array[1024],
+                                 int* error_flag);
+typedef void (*plugin_get_header)(int* nx,
+                                  int* ny,
+                                  int* nbytes,
+                                  float* qx,
+                                  float* qy,
+                                  int* number_of_frames,
+                                  int info_array[1024],
+                                  int* error_flag);
+typedef void (*plugin_get_data)(int* frame_number,
+                                int* nx,
+                                int* ny,
+                                int data_array[],
+                                int info_array[1024],
+                                int* error_flag);
+typedef void (*plugin_close_file)(int* error_flag);
+
+namespace {
+constexpr int NUM_THREADS = 16;
+constexpr int CALLS_PER_THREAD = 100;
+}  // namespace
+
+class TestXdsPluginConcurrent : public TestDatasetArtificialSmall001 {
+public:
+    void SetUp() override {
+        TestDataset::SetUp();
+        pluginHandle = dlopen(PATH_TO_XDS_PLUGIN, RTLD_NOW);
+        ASSERT_NE(pluginHandle, nullptr);
+        open_file = (plugin_open_file)dlsym(pluginHandle, "plugin_open");
+        get_header =
+                (plugin_get_header)dlsym(pluginHandle, "plugin_get_header");
+        get_data = (plugin_get_data)dlsym(pluginHandle, "plugin_get_data");
+        close_file = (plugin_close_file)dlsym(pluginHandle, "plugin_close");
+        error_flag = 1;
+        std::memset(info_array, 0, sizeof(info_array));
+    }
+    void TearDown() override { dlclose(pluginHandle); }
+
+    void* pluginHandle;
+    plugin_open_file open_file;
+    plugin_get_header get_header;
+    plugin_get_data get_data;
+    plugin_close_file close_file;
+    int error_flag;
+    int info_array[1024];
+};
+
+TEST_F(TestXdsPluginConcurrent, ConcurrentGetDataMatchesSingleThreadedReference) {
+    // 1. Open and read header (single-threaded — happens-before any concurrent
+    //    get_data calls per std::thread's spawn-creates-happens-before rule).
+    open_file(getPathToSourceFile().c_str(), info_array, &error_flag);
+    ASSERT_EQ(error_flag, 0);
+
+    int nx, ny, nbytes, total_frames;
+    float qx, qy;
+    get_header(&nx, &ny, &nbytes, &qx, &qy, &total_frames, info_array,
+               &error_flag);
+    ASSERT_EQ(error_flag, 0);
+    ASSERT_GT(total_frames, 0);
+    const size_t frame_pixels = (size_t)nx * (size_t)ny;
+
+    // 2. Build single-threaded reference: read every available frame once,
+    //    serialise the int32 buffer into `reference[frame_index]`.
+    std::vector<std::vector<int32_t>> reference(total_frames);
+    for (int f = 0; f < total_frames; ++f) {
+        reference[f].resize(frame_pixels);
+        int frame_number = f + 1;  // plugin uses 1-indexed frame numbers
+        get_data(&frame_number, &nx, &ny, reference[f].data(), info_array,
+                 &error_flag);
+        ASSERT_EQ(error_flag, 0) << "reference read failed at frame " << frame_number;
+    }
+
+    // 3. Spawn NUM_THREADS workers; each calls plugin_get_data
+    //    CALLS_PER_THREAD times with frame numbers picked from a per-thread
+    //    deterministic random sequence (different seed per thread so frame
+    //    orderings differ across threads).
+    std::atomic<int> mismatch_count{0};
+    std::atomic<int> error_count{0};
+    std::vector<std::thread> workers;
+    workers.reserve(NUM_THREADS);
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        workers.emplace_back([&, t]() {
+            std::mt19937 rng(0xC0FFEE ^ t);  // per-thread deterministic seed
+            std::uniform_int_distribution<int> frame_dist(1, total_frames);
+            std::vector<int32_t> buffer(frame_pixels);
+            int thread_info[1024];
+            std::memset(thread_info, 0, sizeof(thread_info));
+            int thread_error = 0;
+            for (int call = 0; call < CALLS_PER_THREAD; ++call) {
+                int frame_number = frame_dist(rng);
+                get_data(&frame_number, &nx, &ny, buffer.data(), thread_info,
+                         &thread_error);
+                if (thread_error != 0) {
+                    ++error_count;
+                    return;
+                }
+                const auto& ref = reference[frame_number - 1];
+                if (!std::equal(buffer.begin(), buffer.end(), ref.begin())) {
+                    ++mismatch_count;
+                    return;
+                }
+            }
+        });
+    }
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    EXPECT_EQ(error_count.load(), 0)
+            << "one or more workers reported a plugin error";
+    EXPECT_EQ(mismatch_count.load(), 0)
+            << "one or more workers read frame data that differed from "
+               "single-threaded reference";
+
+    // 4. Close (single-threaded — happens-after all worker joins).
+    close_file(&error_flag);
+    ASSERT_EQ(error_flag, 0);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::GTEST_FLAG(catch_exceptions) = false;
+    return RUN_ALL_TESTS();
+}

--- a/src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp
+++ b/src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstring>
 #include <iostream>
 #include <random>
 #include <thread>

--- a/tickets/open/NEGGIA-001-worker-pool-replacing-global-handle.md
+++ b/tickets/open/NEGGIA-001-worker-pool-replacing-global-handle.md
@@ -126,35 +126,78 @@ Quantitative targets:
 
 ## 8-Step Workflow Log
 1. **Ticket:** this file (created 2026-05-29).
-2. **Requirement Spec:** `docs/specs/NEGGIA-001.md` (TODO —
-   `neggia-requirement-spec`). Spec must declare: thread-safety
-   guarantee on `plugin_get_data` (sequentially consistent across
-   any thread interleaving); sync primitive (mutex / atomic / per-worker
-   ownership — audit decides); `Test_XdsPluginConcurrent` exact shape;
-   ABI parity invariant; bit-exact regression invariant.
-3. **Audit & Challenge:** `docs/audits/NEGGIA-001.md` (TODO —
-   `neggia-deep-audit` driving `neggia-archaeologist`). Audit must
-   resolve: (a) is `H5DataCache` thread-safe internally or must each
-   worker get its own?; (b) does removing `GLOBAL_HANDLE` change any
-   single-open invariant currently relied on by `plugin_open`?; (c)
-   what's the minimal pool data structure that fits in ≤ 50 cap units?
-4. **Minimal Patch Proposal:** TODO — `neggia-surgical-patch`. ABI
-   HALT must not trigger (signatures unchanged). 50-line cap must not
-   blow.
-5. **Apply & Verify:** TODO. PR-side CI on
-   `feature/NEGGIA-001-worker-pool`. PASS = all 6 verifications green
-   (build, ctest, ABI parity, TSan, Helgrind, bit-exact).
+2. **Requirement Spec:** DONE 2026-05-29 — `docs/specs/NEGGIA-001.md`.
+   8 invariants, 8 acceptance tests, 7 out-of-scope items, 5 open
+   questions OQ-1..OQ-5.
+3. **Audit & Challenge:** DONE 2026-05-29 — `docs/audits/NEGGIA-001.md`.
+   Verdict: READY_FOR_HUMAN_APPLY (cap-exempt under reporter override).
+   All 5 OQs resolved (OQ-1 H5DataCache thread-safe under Inv-A but
+   per-worker preferred; OQ-2 K=16 hardcoded; OQ-3 candidate (a)
+   per-worker vector; OQ-4 preserve external single-open contract;
+   OQ-5 no fd multiplication). Devil's Advocate: NEGGIA-002's mmap→pread
+   may interact with bit-exactness on GeeseFS — flagged for NEGGIA-002
+   spec.
+4. **Minimal Patch Proposal:** DONE 2026-05-29 — `neggia-surgical-patch`.
+   Source-line count: **67 / 50** (sum of additions + removals;
+   reporter-direct override authorized per § Notes above). 7 files
+   touched: 1 EDIT in `src/dectris/neggia/plugin/H5ToXds.cpp`, 1 NEW
+   `src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp` (test-cap-exempt),
+   1 EDIT `src/dectris/neggia/test/CMakeLists.txt` (framework-exempt),
+   1 NEW `tools/regress_bitexact.sh` (framework-exempt), 1 EDIT
+   `CHANGELOG.md`, ticket+audit edits. Diff summary in audit doc.
+5. **Apply & Verify:** DONE 2026-05-29 (local Mac arm64). Build clean;
+   ctest 9/9 pass incl. new `Test_XdsPluginConcurrent`; AT-1 ABI parity
+   pass (nm parity vs `docs/abi-baseline.txt`); AT-4 TSan clean; AT-5
+   Helgrind DEFERRED to Linux CI (no valgrind on macOS arm64); AT-6
+   bit-exact regression PASS on 9 fixtures (datasets_eiger1+2); AT-8
+   benchmark DEFERRED to NEGGIA-005 scientists-in-cloud.
 6. **Commit/PR:** TODO. Branch `feature/NEGGIA-001-worker-pool`.
    Commit subject `perf(NEGGIA-001): worker pool replacing
    GLOBAL_HANDLE singleton`.
-7. **Changelog:** TODO — `[Unreleased] → Changed`. One entry
-   describing the singleton-to-pool transition + ABI preservation +
-   ctest additions.
-8. **Learning:** Encouraged — first real exercise of the neggia
-   framework; worth capturing any surprises in the C++ archaeology
-   patterns vs Fortran (XDS-fork) precedent.
+7. **Changelog:** DONE 2026-05-29 — `[Unreleased] → Changed` entry
+   recording the singleton-to-pool transition, ABI preservation, new
+   ctest, verification results, and the cap-exemption note.
+8. **Learning:** TODO — first real C++ exercise of the neggia framework.
+   Worth capturing: (a) the audit-vs-skill cap-projection methodology
+   mismatch (net vs sum) that triggered HALT-then-override; (b) the
+   Inv-A discovery (H5DataCache is write-once-then-immutable) that
+   made per-worker ownership cheap; (c) Helgrind unavailability on
+   macOS arm64 — implications for the verification matrix.
 
 ## Notes
+
+### Reporter-direct cap exemption (2026-05-29)
+
+`neggia-surgical-patch` reported `HALTED_FOR_RESCOPE` at ~67/50 cap
+units (sum of additions + removals; 27 removed + 40 added per audit
+§Minimal Patch Proposal — HALTED). Audit's OQ-3 cap projection
+(17-27 units) was net-delta, not sum; the skill rule is sum.
+
+**Reporter override**: I (Max Burian, max.burian@dectris.com)
+authorize a one-time cap exemption to land NEGGIA-001 as a single
+ticket / single PR at ~67 cap units (~1.3× the 50-unit cap).
+
+**Rationale**: Worker-pool introduction is structurally one logical
+change. The framework-discipline split into NEGGIA-001 (struct prep)
++ NEGGIA-006 (K-expansion) would introduce a no-op intermediate
+commit (K=1 pool that's just a vector-wrapped singleton with
+identical behaviour to pre-patch) — pure churn with zero
+observable delivery between commits. Cleanest delivery is a single
+ticket that lands the structural + behavioural change together.
+
+**Precedent**: XDS-036 (dual-license model rollout, 2026-05-05)
+took a 155-cap-unit exemption (~3.1× cap) with similar
+single-ticket rationale. NEGGIA-001's exemption is more modest
+(~1.3×) and similarly contained.
+
+**Sibling housekeeping** (to be filed post-NEGGIA-001 close):
+update `neggia-deep-audit` skill body's OQ cap-projection
+methodology to use **sum** (not net delta), aligning with
+`neggia-surgical-patch`'s rule. Cap reaffirmed in force for all
+subsequent NEGGIA-NNN tickets.
+
+### Original notes
+
 - Audit Devil's Advocate prompt suggestions: "If H5DataCache holds
   any thread-affine state (e.g. errno-style last-error fields), the
   pool-of-shared approach breaks silently. What does the audit see

--- a/tools/regress_bitexact.sh
+++ b/tools/regress_bitexact.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# tools/regress_bitexact.sh
+# NEGGIA-001 AT-6: bit-exact regression of post-patch plugin against
+# a pre-patch baseline. For each fixture master file under the given
+# fixture directories, call plugin_get_data for every available frame
+# via both .so files and assert byte-equality.
+#
+# Usage:
+#   tools/regress_bitexact.sh <baseline_so> <candidate_so> <fixture_dir1> [<fixture_dir2> ...]
+#
+# Where each <fixture_dir> contains one or more subdirectories with a
+# master *.h5 file (e.g. src/dectris/neggia/test/h5-testfiles/datasets_eiger1).
+#
+# Exit 0 on full success; exit 1 on first mismatch or plugin error.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 <baseline_so> <candidate_so> <fixture_dir1> [<fixture_dir2> ...]" >&2
+  exit 2
+fi
+
+BASELINE_SO="$1"; shift
+CANDIDATE_SO="$1"; shift
+[ -f "$BASELINE_SO" ] || { echo "FATAL: baseline .so not found: $BASELINE_SO" >&2; exit 2; }
+[ -f "$CANDIDATE_SO" ] || { echo "FATAL: candidate .so not found: $CANDIDATE_SO" >&2; exit 2; }
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Inline C++ helper: load a .so, open a master.h5, dump each frame to stdout.
+# Output format per-frame: 8-byte size, then raw int32 pixels.
+RUNNER_SRC="$WORKDIR/runner.cpp"
+RUNNER_BIN="$WORKDIR/runner"
+cat > "$RUNNER_SRC" <<'EOF'
+#include <dlfcn.h>
+#include <unistd.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+typedef void (*plugin_open_t)(const char*, int[1024], int*);
+typedef void (*plugin_get_header_t)(int*, int*, int*, float*, float*, int*,
+                                    int[1024], int*);
+typedef void (*plugin_get_data_t)(int*, int*, int*, int*, int[1024], int*);
+typedef void (*plugin_close_t)(int*);
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <so> <master.h5>\n", argv[0]);
+        return 2;
+    }
+    void* h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen failed: %s\n", dlerror()); return 2; }
+    auto open_f = (plugin_open_t)dlsym(h, "plugin_open");
+    auto hdr_f = (plugin_get_header_t)dlsym(h, "plugin_get_header");
+    auto data_f = (plugin_get_data_t)dlsym(h, "plugin_get_data");
+    auto close_f = (plugin_close_t)dlsym(h, "plugin_close");
+    if (!open_f || !hdr_f || !data_f || !close_f) {
+        fprintf(stderr, "dlsym failed\n"); return 2;
+    }
+    int info[1024] = {0};
+    int err = 1;
+    open_f(argv[2], info, &err);
+    if (err != 0) { fprintf(stderr, "plugin_open err=%d\n", err); return 3; }
+    int nx, ny, nbytes, total;
+    float qx, qy;
+    hdr_f(&nx, &ny, &nbytes, &qx, &qy, &total, info, &err);
+    if (err != 0) { fprintf(stderr, "plugin_get_header err=%d\n", err); return 3; }
+    fprintf(stderr, "runner: nx=%d ny=%d total_frames=%d\n", nx, ny, total);
+    int* buf = (int*)malloc((size_t)nx * (size_t)ny * sizeof(int));
+    if (!buf) { fprintf(stderr, "OOM\n"); return 3; }
+    for (int f = 1; f <= total; ++f) {
+        data_f(&f, &nx, &ny, buf, info, &err);
+        if (err != 0) {
+            fprintf(stderr, "plugin_get_data(frame=%d) err=%d\n", f, err);
+            free(buf); return 4;
+        }
+        size_t bytes = (size_t)nx * (size_t)ny * sizeof(int);
+        fwrite(&bytes, sizeof(size_t), 1, stdout);
+        fwrite(buf, 1, bytes, stdout);
+    }
+    free(buf);
+    close_f(&err);
+    dlclose(h);
+    return 0;
+}
+EOF
+
+# Compile the helper once.
+CXX="${CXX:-c++}"
+"$CXX" -std=c++11 -O2 -o "$RUNNER_BIN" "$RUNNER_SRC" -ldl
+
+discovered_fixtures=0
+mismatches=0
+errors=0
+
+for fixture_dir in "$@"; do
+  if [ ! -d "$fixture_dir" ]; then
+    echo "WARN: fixture dir not found, skipping: $fixture_dir" >&2
+    continue
+  fi
+  # Each dataset subdir under fixture_dir is expected to contain a master_*.h5
+  # (or similar; we look for *master*.h5).
+  while IFS= read -r master; do
+    discovered_fixtures=$((discovered_fixtures + 1))
+    echo "=== fixture: $master ===" >&2
+    BASELINE_OUT="$WORKDIR/baseline.bin"
+    CANDIDATE_OUT="$WORKDIR/candidate.bin"
+    if ! "$RUNNER_BIN" "$BASELINE_SO" "$master" > "$BASELINE_OUT" 2>"$WORKDIR/baseline.log"; then
+      echo "ERROR: baseline runner failed on $master" >&2
+      cat "$WORKDIR/baseline.log" >&2
+      errors=$((errors + 1)); continue
+    fi
+    if ! "$RUNNER_BIN" "$CANDIDATE_SO" "$master" > "$CANDIDATE_OUT" 2>"$WORKDIR/candidate.log"; then
+      echo "ERROR: candidate runner failed on $master" >&2
+      cat "$WORKDIR/candidate.log" >&2
+      errors=$((errors + 1)); continue
+    fi
+    if cmp -s "$BASELINE_OUT" "$CANDIDATE_OUT"; then
+      echo "OK: $master byte-identical" >&2
+    else
+      echo "MISMATCH: $master" >&2
+      mismatches=$((mismatches + 1))
+    fi
+  done < <(find "$fixture_dir" -type f -name '*master*.h5')
+done
+
+echo "=== summary: $discovered_fixtures fixture(s) checked; $mismatches mismatch(es); $errors error(s) ===" >&2
+
+if [ "$discovered_fixtures" -eq 0 ]; then
+  echo "FATAL: no fixtures discovered under: $*" >&2
+  exit 2
+fi
+if [ "$errors" -gt 0 ] || [ "$mismatches" -gt 0 ]; then
+  exit 1
+fi
+echo "PASS: all fixtures byte-identical across baseline + candidate"
+exit 0


### PR DESCRIPTION
## Summary

- Stage 1 of Tier-1 perf overhaul per XDS-037 RFC (`docs/plans/tier-1-performance.md`).
- Replaces `GLOBAL_HANDLE` singleton with `NUM_WORKERS=16` `H5DataCache` pool; each worker owns its own `H5File` (per-worker mmap = per-worker kernel readahead state — load-bearing for the GeeseFS-S3 concurrency win).
- `plugin_get_data` dispatches by `frame_number % NUM_WORKERS`; lock-free hot path; per-worker state thread-confined.
- The 4 sacred `plugin_*` C ABI symbols retain byte-identical signatures (downstream XDS-fork `tools/neggia-version.txt` bump stays clean).
- External single-open contract preserved.

## Concurrency-safety argument

Per audit Inv-A (see `docs/audits/NEGGIA-001.md`): all `dataCache->*` writes happen during `plugin_open` + `plugin_get_header`; `plugin_get_data` reads only. After header phase, each worker's `H5DataCache` is effectively immutable. Per-worker ownership + frame-modulo dispatch means zero shared mutable state on the hot path — no mutex / atomic / condvar needed for `plugin_get_data`.

## Local verification (Mac arm64)

| AT | Test | Result |
|---|---|---|
| AT-1 | ABI parity (`nm` vs `docs/abi-baseline.txt`) | ✓ PASS |
| AT-2 | Existing 8 ctests + new concurrent | ✓ PASS (9/9) |
| AT-3 | `Test_XdsPluginConcurrent` (16 threads × 100 calls, bit-equality vs single-threaded reference) | ✓ PASS |
| AT-4 | TSan clean on `Test_XdsPluginConcurrent` | ✓ PASS (0 reports) |
| AT-5 | Helgrind clean | ⏸ DEFERRED (no valgrind on macOS arm64; verify on Linux CI) |
| AT-6 | Bit-exact regression vs master baseline | ✓ PASS (9 fixtures byte-identical: eiger1+eiger2; uint8/uint16/uint32; BSLZ4/LZ4/uncompressed; 0/2 data-file variants) |
| AT-7 | Source-line cap | 67 / 50 (reporter override; see ticket Notes — precedent XDS-036) |
| AT-8 | Scientists-in-cloud GeeseFS-S3 benchmark (≥1.3× wall-clock) | ⏸ DEFERRED to NEGGIA-005 release-time validation |

## Reporter-direct cap exemption

Authorized 2026-05-29 by Max Burian. Rationale: worker-pool introduction is structurally one logical change. The framework-discipline split into NEGGIA-001 (struct prep) + NEGGIA-006 (K-expansion) would introduce a no-op intermediate commit (K=1 pool that's a vector-wrapped singleton with identical behaviour); cleanest delivery is a single PR. Cap reaffirmed for subsequent NEGGIA-NNN tickets. Sibling housekeeping ticket pending to update `neggia-deep-audit` skill body's cap-projection methodology (net delta → sum).

Precedent: XDS-036 (2026-05-05, 155 cap units / 3.1× cap).

## Files changed (8)

- `src/dectris/neggia/plugin/H5ToXds.cpp` (EDIT, +60/-20 src lines)
- `src/dectris/neggia/test/Test_XdsPluginConcurrent.cpp` (NEW, ~130 lines; test-cap-exempt)
- `src/dectris/neggia/test/CMakeLists.txt` (EDIT, +14 lines; framework-exempt)
- `tools/regress_bitexact.sh` (NEW +x, ~110 lines; framework-exempt)
- `CHANGELOG.md` (EDIT)
- `docs/specs/NEGGIA-001.md` (NEW, full spec)
- `docs/audits/NEGGIA-001.md` (NEW, full audit + Minimal Patch Proposal section)
- `tickets/open/NEGGIA-001-…md` (workflow log updates + reporter-override Notes)

## Test plan

- [ ] CI green (whatever upstream neggia CI exists; will surface after PR open)
- [ ] Helgrind verification on Linux (separate session if needed)
- [ ] Eventually: scientists-in-cloud GeeseFS-S3 benchmark per NEGGIA-005

## Workflow

Per the cross-repo agent framework (`docs/architecture/agent-framework.md`); driven from the sibling xds-fork Claude session. Closes NEGGIA-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)